### PR TITLE
Feature/refactor state

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# http://EditorConfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,5 +28,6 @@ module.exports = {
     "import/no-unresolved": 0,
     "react/sort-comp": 0,
     "react/jsx-filename-extension": 0,
+    "no-unused-prop-types": 0, // https://github.com/yannickcr/eslint-plugin-react/issues/885
   }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,5 @@ module.exports = {
     "import/no-unresolved": 0,
     "react/sort-comp": 0,
     "react/jsx-filename-extension": 0,
-    "no-unused-prop-types": 0, // https://github.com/yannickcr/eslint-plugin-react/issues/885
   }
 };

--- a/index.js
+++ b/index.js
@@ -38,9 +38,11 @@ export default class Grid extends Component {
     itemHasChanged: React.PropTypes.func,
     renderItem: React.PropTypes.func.isRequired,
     renderPlaceholder: React.PropTypes.func,
+    renderSectionHeader: React.PropTypes.func,
     data: React.PropTypes.arrayOf(React.PropTypes.any).isRequired,
     refreshControl: React.PropTypes.element,
     renderFooter: React.PropTypes.func,
+    sections: React.PropTypes.boolean,
   };
 
   static defaultProps = {
@@ -52,22 +54,24 @@ export default class Grid extends Component {
     renderFooter: () => null,
     refreshControl: <RefreshControl refreshing={false} />,
     renderPlaceholder: () => null,
+    renderSectionHeader: () => null,
+    sections: false,
+    data: [],
   };
 
   state = {
     dataSource: new ListView.DataSource({
-        rowHasChanged: (r1, r2) => r1.some((e, i) => props.itemHasChanged(e, r2[i])),
-        sectionHeaderHasChanged: (s1, s2) => s1 !== s2,
+      rowHasChanged: (r1, r2) => r1.some((e, i) => this.props.itemHasChanged(e, r2[i])),
+      sectionHeaderHasChanged: (s1, s2) => s1 !== s2,
     }),
   };
 
   componentWillReceiveProps(nextProps) {
-      this.state.dataSource = nextProps.sections
-          ? this.state.dataSource
-              .cloneWithRowsAndSections(this._prepareSectionedData(nextProps.data))
-          : this.state.dataSource
-              .cloneWithRows(this._prepareData(nextProps.data))
-    }
+    this.state.dataSource = nextProps.sections
+      ? this.state.dataSource
+        .cloneWithRowsAndSections(this._prepareSectionedData(nextProps.data))
+      : this.state.dataSource
+        .cloneWithRows(this._prepareData(nextProps.data));
   }
 
   _prepareSectionedData = data => {
@@ -89,7 +93,7 @@ export default class Grid extends Component {
   _renderPlaceholder = i =>
     <View key={i} style={{ width: width / this.props.itemsPerRow }} />;
 
-  _renderRow = rowData =>
+  _renderRow = rowData => (
     <View style={styles.row}>
       {rowData.map((item, i) => {
         if (item) {
@@ -101,7 +105,8 @@ export default class Grid extends Component {
         }
         return this._renderPlaceholder(i);
       })}
-    </View>;
+    </View>
+  );
 
   render() {
     return (

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ import {
   View,
   ListView,
   Dimensions,
+  RefreshControl,
 } from 'react-native';
 
 const { height, width } = Dimensions.get('window');
@@ -38,9 +39,9 @@ export default class Grid extends Component {
     renderItem: React.PropTypes.func.isRequired,
     renderPlaceholder: React.PropTypes.func,
     data: React.PropTypes.arrayOf(React.PropTypes.any).isRequired,
-    refreshControl: React.PropTypes.func,
+    refreshControl: React.PropTypes.element,
     renderFooter: React.PropTypes.func,
-  }
+  };
 
   static defaultProps = {
     itemsPerRow: 3,
@@ -49,10 +50,10 @@ export default class Grid extends Component {
       return r1 !== r2;
     },
     renderFooter: () => null,
-    refreshControl: () => null,
+    refreshControl: <RefreshControl refreshing={false} />,
     renderPlaceholder: () => null,
+  };
 
-  }
   constructor(props: Object) {
     super(props);
 
@@ -87,7 +88,7 @@ export default class Grid extends Component {
   _prepareSectionedData = data => {
     const preparedData = mapValues(data, (vals) => this._prepareData(vals));
     return preparedData;
-  }
+  };
 
   _prepareData = data => {
     const rows = chunk(data, this.props.itemsPerRow);
@@ -98,10 +99,10 @@ export default class Grid extends Component {
       }
     }
     return rows;
-  }
+  };
 
   _renderPlaceholder = i =>
-    <View key={i} style={{ width: width / this.props.itemsPerRow }} />
+    <View key={i} style={{ width: width / this.props.itemsPerRow }} />;
 
   _renderRow = rowData =>
     <View style={styles.row}>
@@ -115,7 +116,7 @@ export default class Grid extends Component {
         }
         return this._renderPlaceholder(i);
       })}
-    </View>
+    </View>;
 
   render() {
     return (

--- a/index.js
+++ b/index.js
@@ -54,34 +54,19 @@ export default class Grid extends Component {
     renderPlaceholder: () => null,
   };
 
-  constructor(props: Object) {
-    super(props);
-
-    const ds = new ListView.DataSource({
-      rowHasChanged: (r1, r2) => r1.some((e, i) => props.itemHasChanged(e, r2[i])),
-      sectionHeaderHasChanged: (s1, s2) => s1 !== s2,
-    });
-    if (props.sections === true) {
-      this.state = {
-        dataSource: ds.cloneWithRowsAndSections(this._prepareSectionedData(this.props.data)),
-      };
-    } else {
-      this.state = {
-        dataSource: ds.cloneWithRows(this._prepareData(this.props.data)),
-      };
-    }
-  }
+  state = {
+    dataSource: new ListView.DataSource({
+        rowHasChanged: (r1, r2) => r1.some((e, i) => props.itemHasChanged(e, r2[i])),
+        sectionHeaderHasChanged: (s1, s2) => s1 !== s2,
+    }),
+  };
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.sections === true) {
-      this.state = {
-        dataSource: this.state.dataSource
-          .cloneWithRowsAndSections(this._prepareSectionedData(nextProps.data)),
-      };
-    } else {
-      this.setState({
-        dataSource: this.state.dataSource.cloneWithRows(this._prepareData(nextProps.data)),
-      });
+      this.state.dataSource = nextProps.sections
+          ? this.state.dataSource
+              .cloneWithRowsAndSections(this._prepareSectionedData(nextProps.data))
+          : this.state.dataSource
+              .cloneWithRows(this._prepareData(nextProps.data))
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "eslint-config-airbnb": "^14.1.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
-    "eslint-plugin-react": "6.10.0"
+    "eslint-plugin-react": "Kerumen/eslint-plugin-react#master"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "eslint-config-airbnb": "^14.1.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
-    "eslint-plugin-react": "^6.4.1"
+    "eslint-plugin-react": "6.10.0"
   }
 }


### PR DESCRIPTION
1. Do not need to create constructor - React.Component already have it.
Actually, for custom React.Component we need create *dafault state* only, which is `state` property of our class;

So, I move setting the state property from **constructor** to **state**

2. `componentWillReceiveProps` called each time, before component has rendered. So, changing *dataSource* with *cloneWithRowsAndSections* or *cloneWithRows* also can be refactored.

DRY.