### PR TITLE
refactor: only pass props that ListView can handle

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,10 +122,19 @@ export default class Grid extends Component {
     </View>
 
   render() {
+    const {
+        renderPlaceholder,
+        renderItem,
+        itemsPerRow,
+        itemHasChanged,
+        data,
+        sections,
+        ...props
+    } = this.props;
     return (
       <View style={styles.container}>
         <ListView
-          {...this.props}
+          {...props}
           style={styles.list}
           dataSource={this.state.dataSource}
           renderRow={this._renderRow}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16645288/30510485-b9e9f190-9ae2-11e7-85cc-986bafafe83d.png)

using Grid component with react-native-web raises unknown prop warnings, since RNW further passes down incoming props to div. Some props like renderPlaceholder are meant to be used by Grid component only & should be avoided passing down to ListView.